### PR TITLE
Add public API for emission data

### DIFF
--- a/carbon-aware/pkg/sdk/api/emissions_data.go
+++ b/carbon-aware/pkg/sdk/api/emissions_data.go
@@ -1,0 +1,12 @@
+package api
+
+import (
+	"time"
+)
+
+type EmissionsData struct {
+	Location string    `json:"location,omitempty"`
+	Time     time.Time `json:"time,omitempty"`
+	Rating   float64   `json:"rating,omitempty"`
+	Duration string    `json:"duration,omitempty"`
+}


### PR DESCRIPTION
This change reuses the carbon aware SDK data model for the data structure stored in the K8s configmap. 